### PR TITLE
azurerm => azure in registry name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add a reference to this module to your tf code, like this:
 ```make
 module "statebucket"
 {
-  source      = "JamesWoolfenden/statebucket/azurerm"
+  source      = "JamesWoolfenden/statebucket/azure"
   version     = "0.0.8"
   common_tags = var.common_tags
 }


### PR DESCRIPTION
Hiya, I couldn't download the module from registry.terraform.io because the name in the README doesn't match that of registry.terraform.io. This updates the doc. Best 😄 