### PR TITLE
Removes to-be deprecated arg resource_group_name

### DIFF
--- a/azurerm_storage_container.terraform.tf
+++ b/azurerm_storage_container.terraform.tf
@@ -1,6 +1,5 @@
 resource "azurerm_storage_container" "terraform" {
   name                  = "tfstate"
-  resource_group_name   = azurerm_resource_group.terraform.name
   storage_account_name  = azurerm_storage_account.terraform.name
   container_access_type = "private"
 }

--- a/example/exampleA/provider.azurerm.tf
+++ b/example/exampleA/provider.azurerm.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "1.31"
+  version = "1.35"
 }
 
 provider "local" {


### PR DESCRIPTION
Hi again,

I get this result when I `terraform plan` on this module:
```shell
Warning: "resource_group_name": [DEPRECATED] This field has been deprecated and is no longer used - will be removed in 2.0 of the Azure Provider
```
Removing the argument makes it go away.

Best 😊 